### PR TITLE
Fix minor bugs in utilities

### DIFF
--- a/xgym/utils/boundary.py
+++ b/xgym/utils/boundary.py
@@ -271,8 +271,8 @@ class JointBoundary(Boundary):
     max: PartialRobotState
 
     def post_init(self):
-        assert len(self.min.joins) == 7
-        assert len(self.max.joins) == 7
+        assert len(self.min.joints) == 7
+        assert len(self.max.joints) == 7
 
     def contains(self, state: PartialRobotState) -> bool:
         """Checks if the given robot state is within the joint limits.

--- a/xgym/viz/memmap.py
+++ b/xgym/viz/memmap.py
@@ -22,12 +22,12 @@ def fold_angle(theta: np.ndarray) -> np.ndarray:
     )
 
 
-def read_all(root=Path().cwd(), view=False):
+def read_all(root=Path().cwd(), show=False):
     paths = list(root.rglob("*.dat"))
     print(paths)
     for p in paths:
-        read(p)
-        if view:
+        info, data = read(p)
+        if show:
             view(data)
 
 


### PR DESCRIPTION
## Summary
- fix `read_all()` to return data and rename its boolean argument
- fix attribute typo in `JointBoundary.post_init`

## Testing
- `python - <<'PY'
import py_compile,sys,os
files=[f.strip() for f in os.popen("git ls-files '*.py'").read().splitlines()]
for f in files:
    if not os.path.exists(f):
        print('Skipping missing', f)
        continue
    try:
        py_compile.compile(f, doraise=True)
    except Exception as e:
        print('Error compiling', f, e)
        sys.exit(1)
print('All files compiled')
PY`